### PR TITLE
Addressカラムに追加

### DIFF
--- a/db/migrate/20200408130125_add_sending_info_to_address.rb
+++ b/db/migrate/20200408130125_add_sending_info_to_address.rb
@@ -1,0 +1,10 @@
+class AddSendingInfoToAddress < ActiveRecord::Migration[5.2]
+  def change
+    add_column :addresses, :sending_first_name, :string,       null: false
+    add_column :addresses, :sending_last_name, :string,        null: false
+    add_column :addresses, :sending_first_name_kana, :string,  null: false
+    add_column :addresses, :sending_last_name_kana, :string,   null: false
+    add_column :addresses, :postal_code, :integer,             null: false
+    add_column :addresses, :phone, :integer,                   null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_02_134705) do
+ActiveRecord::Schema.define(version: 2020_04_08_130125) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "prefecture", null: false
@@ -20,6 +20,12 @@ ActiveRecord::Schema.define(version: 2020_04_02_134705) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "sending_first_name", null: false
+    t.string "sending_last_name", null: false
+    t.string "sending_first_name_kana", null: false
+    t.string "sending_last_name_kana", null: false
+    t.integer "postal_code", null: false
+    t.integer "phone", null: false
     t.index ["user_id"], name: "index_addresses_on_user_id"
   end
 


### PR DESCRIPTION
#WHAT
Addressカラムに送付先の名字・名前とそのカナ読み計４種と郵便番号、電話番号のカラムを追加しました。
#WHY
ユーザー登録の際に住所と一緒に郵便番号と電話番号、ユーザーの登録情報とは別に送付先情報としてのユーザーの氏名が必要だったため。

コードに問題がなさそうならmigrateを行います。