### PR TITLE
deviseの値が登録されるように修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,12 @@
 class ApplicationController < ActionController::Base
   before_action :basic_auth, if: :production?
+  before_aciton :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :first_name, :last_name, :first_name_kana, :last_name_kana, :birthday, :money, :image, :point])
+  end
 
   private
   def production?


### PR DESCRIPTION
# What
application_controllerに、deviseの初期パラメータ以外の許可を記載。

# Why
deviseの初期パラメータ以外の情報を登録できることで、ユーザーの情報をたくさん扱うことができるため。