### PR TITLE
郵便番号のバリデーションのテストを追加

### DIFF
--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -69,6 +69,20 @@ describe Address do
       expect(address).to be_valid
     end
 
+    # 郵便番号が半角数字の時以外登録できない
+    it "郵便番号が半角数字の時以外登録できない" do
+      address = build(:address, postal_code: "ああああああ")
+      address.valid?
+      expect(address.errors[:postal_code]).to include("is not a number")
+    end
+    
+    # 郵便番号が半角数字のみの場合登録できる
+    it "郵便番号が半角数字のみの場合登録できる" do
+      address = build(:address, postal_code: "1111111")
+      address.valid?
+      expect(address).to be_valid
+    end
+
     # 都道府県は入力しているか
     it "it valid with a prefecture_id that has less than 48" do
       address = build(:address, prefecture_id: "48")
@@ -88,6 +102,5 @@ describe Address do
       address.valid?
       expect(address).to be_valid
     end
-
   end
 end 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -152,34 +152,5 @@ describe User do
       user.valid?
       expect(user).to be_valid
     end
-
-    # 郵便番号が半角数字のみの場合登録できる
-    it "is vaild with a postal_code that has only 7 characters" do
-      user = build(:user, postal_code:)
-      user.valid?
-      expect(user).to be_valid
-    end
-
-    # 郵便番号が7文字ではないとき登録できない
-    it "is invaild with a password that has less than 6 characters" do
-      user = build(:user, password: "10ako", password_confirmation: "10ako")
-      user.valid?
-      expect(user.errors[:password]).to include("is too short (minimum is 6 characters)", "is too short (minimum is 7 characters)")
-    end
-
-    # 郵便番号が7文字の時は登録できる
-    it "is valid with a password that contains letters and numbers" do
-      user = build(:user, password: "1t0okaa", password_confirmation: "1t0okaa")
-      user.valid?
-      expect(user).to be_valid
-    end
-
-    # 郵便番号が半角数字の時以外登録できない
-    it "is invalid without a point" do
-      user = build(:user, point: nil)
-      user.valid?
-      expect(user.errors[:point]).to include("can't be blank")
-    end
-
   end
 end


### PR DESCRIPTION
# What
郵便番号が半角数字のみ入力可能のバリデーションを追加したため、テストを行った

# Why
郵便番号におかしなデータが入力されると、取引がうまくいかなくなってしまうため

https://gyazo.com/fc8e889ede453ddffcc308042f7fd185