### PR TITLE
Creditcard serverside#2 fix

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -8,7 +8,7 @@ class Item < ApplicationRecord
   accepts_nested_attributes_for :item_images,allow_destroy: true
   belongs_to :user
   belongs_to :category
-  belongs_to :transaction
+  has_one :tx, class_name: 'Transaction'
 
   # scope
   # カテゴリごとにアイテムを６つまで取得する

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -8,7 +8,7 @@ class Item < ApplicationRecord
   accepts_nested_attributes_for :item_images,allow_destroy: true
   belongs_to :user
   belongs_to :category
-  has_one :tx, class_name: 'Transaction'
+  belongs_to :transaction
 
   # scope
   # カテゴリごとにアイテムを６つまで取得する

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -1,5 +1,6 @@
 class Transaction < ApplicationRecord
   belongs_to :item
-  has_many :users, through: :user_transactions
+  has_many :saler, class_name: 'Users', through: :user_transactions
+  has_many :buyer, class_name: 'Users', through: :user_transactions
   has_many :user_transactions
 end

--- a/app/models/user_transaction.rb
+++ b/app/models/user_transaction.rb
@@ -1,4 +1,5 @@
-class UserTransactiom < ApplicationRecord
-  belongs_to :user
+class UserTransaction < ApplicationRecord
+  belongs_to :buyer, class_name: 'User'
+  belongs_to :saler, class_name: 'User'
   belongs_to :transaction
 end

--- a/app/models/user_transaction.rb
+++ b/app/models/user_transaction.rb
@@ -1,4 +1,5 @@
 class UserTransactiom < ApplicationRecord
-  belongs_to :user
+  belongs_to :buyer, class_name: 'User'
+  belongs_to :saler, class_name: 'User'
   belongs_to :transaction
 end

--- a/app/models/user_transaction.rb
+++ b/app/models/user_transaction.rb
@@ -1,5 +1,4 @@
-class UserTransaction < ApplicationRecord
-  belongs_to :buyer, class_name: 'User'
-  belongs_to :saler, class_name: 'User'
+class UserTransactiom < ApplicationRecord
+  belongs_to :user
   belongs_to :transaction
 end


### PR DESCRIPTION
# What
- Transactionという名前が使えないため、別名に修正
- 取引時に、user情報を買い手・売り手に分けて保存できるように修正

# Why
取引上で、売り手・買い手が混ざってしまうと、支払いがうまくいかないため