### PR TITLE
購入確認画面に追加

### DIFF
--- a/app/assets/stylesheets/_satou.scss
+++ b/app/assets/stylesheets/_satou.scss
@@ -423,6 +423,16 @@
   color:white;
   border-radius: 8px;
 }
+.cantgobutton{
+  background-color: gray;
+  width: 350px;
+  height: 50px;
+  font-size:18px;
+  color:white;
+  border-radius: 8px;
+  text-align: center;
+  line-height: 50px;
+}
 .gobuy{
   background-color: red;
   width: 560px;

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -3,6 +3,7 @@ class TransactionsController < ApplicationController
 
   def confirm
     @card = Card.find_by(user_id: current_user.id)
+    if @card.present?
     Payjp.api_key = Rails.application.credentials.PAYJP_SECRET_KEY
     customer = Payjp::Customer.retrieve(@card.customer_id)
     @customer_card = customer.cards.retrieve(@card.card_id)
@@ -23,7 +24,7 @@ class TransactionsController < ApplicationController
     when "Discover"
       @card_src = "cards/discover.svg"
     end
-
+  end
     @item=Item.find(params[:id])
   end
 

--- a/app/views/transactions/confirm.html.haml
+++ b/app/views/transactions/confirm.html.haml
@@ -37,7 +37,6 @@
          カード番号
          .pa__trade__pay__card__credit--number--out
           **** **** **** #{@customer_card.last4}
-       .pa__trade__pay__card__credit--limit
         .pa__trade__pay__card__credit--limit
          有効期限
         .pa__trade__pay__card__credit--limit

--- a/app/views/transactions/confirm.html.haml
+++ b/app/views/transactions/confirm.html.haml
@@ -29,20 +29,23 @@
 
     .pa__trade__pay__card
      .pa__trade__pay__card--in
+     - if @card.present?
       クレジットカード
-     .pa__trade__pay__card__credit
-      .pa__trade__pay__card__credit--number
-       .pa__trade__pay__card__credit--number--in
-        カード番号
-        .pa__trade__pay__card__credit--number--out
-         **** **** **** #{@customer_card.last4}
-      .pa__trade__pay__card__credit--limit
+      .pa__trade__pay__card__credit
+       .pa__trade__pay__card__credit--number
+        .pa__trade__pay__card__credit--number--in
+         カード番号
+         .pa__trade__pay__card__credit--number--out
+          **** **** **** #{@customer_card.last4}
        .pa__trade__pay__card__credit--limit
-        有効期限
-       .pa__trade__pay__card__credit--limit
-        #{@customer_card.exp_month.to_s} / #{@customer_card.exp_year.to_s.slice(2,3)}
-       .pa__trade__pay__card__credit--logo
-        = image_tag @card_src, width:'49px', height: '20px', class: 'visa'
+        .pa__trade__pay__card__credit--limit
+         有効期限
+        .pa__trade__pay__card__credit--limit
+         #{@customer_card.exp_month.to_s} / #{@customer_card.exp_year.to_s.slice(2,3)}
+        .pa__trade__pay__card__credit--logo
+         = image_tag @card_src, width:'49px', height: '20px', class: 'visa'
+     - else
+      クレジットカードが登録されていません
    .pa__trade__deliver
     .pa__trade__deliver__box
      .pa__trade__deliver__box__toward
@@ -60,5 +63,9 @@
       =current_user.nickname
   .pa__go
    .pa__go--button
-    %button.gobutton 購入する
+    - if @card.present?
+     %button.gobutton 購入する
+    - else
+     .pa__go--button.cantgobutton カード登録をしてください
+
 = render 'items/footer'


### PR DESCRIPTION
# what
購入確認ページにてクレジットカードの登録がない場合の画像表示を設定

# why
クレジットカードを登録していないユーザーの購入を防止するため。

https://gyazo.com/48d224c3e0c9ce806796bc6955f1d58a