### PR TITLE
商品詳細ページのlink_toが文字しか反応しないのを修正

### DIFF
--- a/app/assets/stylesheets/_satou.scss
+++ b/app/assets/stylesheets/_satou.scss
@@ -380,6 +380,10 @@
 
 }
 
+.btn {
+  display: block;
+}
+
 
 
 
@@ -434,6 +438,8 @@
   line-height: 50px;
 }
 .gobuy{
+  margin: auto;
+  line-height: 50px;
   background-color: red;
   width: 560px;
   height: 50px;

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -27,8 +27,7 @@
   - else
    - if user_signed_in?
     .de__parchase
-     %button.gobuy
-      =link_to '購入画面に進む',confirm_transaction_path
+     =link_to '購入画面に進む',confirm_transaction_path, class: "gobuy btn"
   .de__exp
    = @item.explanation
   .de__table


### PR DESCRIPTION
# What
link_toがボタン全体に適用されるようにした

# Why
ボタン全体が押せたほうがユーザーにとって操作しやすいため

https://gyazo.com/8081ebf0e5564ba813875477cc23fcd5